### PR TITLE
fix(quark): replace version by a string in quark definition

### DIFF
--- a/AlgaLib.quark
+++ b/AlgaLib.quark
@@ -4,5 +4,5 @@
 	summary:		"Interpolating live coding environment",
 	author:			"vitreo12",
 	helpdoc:		"HelpSources/Classes/Alga.schelp",
-	version:		1.1.1,
+	version:		"1.1.1",
 )


### PR DESCRIPTION
Hi, I'm experiencing an issue after installing AlgaLib in Quarks:

```
  ERROR: Syntax error, unexpected INTEGER, expecting NAME or WHILE or '[' or '('
    in interpreted text
    line 7 char 16:

    version:    1.1.1,
                 ^
```
During last update, you bumped the version from 1.1 to 1.1.1.
Without quotes I guess it was working because Quarks was probably using the
value as a float. Now it can only be a string, so it should be protected.